### PR TITLE
OZ-23467 Update dependency versions in package.json

### DIFF
--- a/samples/flows/student-benefits/non-paginated/package.json
+++ b/samples/flows/student-benefits/non-paginated/package.json
@@ -4,14 +4,16 @@
   "version": "0.0.0",
   "license": "MIT",
   "devDependencies": {
-    "ts-loader": "9.3.0",
-    "typescript": "4.5.5",
-    "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.11.1"
+    "@types/node": "18.0.0",
+    "ts-loader": "9.5.4",
+    "tslib": "^2.8.1",
+    "typescript": "4.9.5",
+    "webpack": "^5.108.3",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.2.5"
   },
   "dependencies": {
     "@oracle/ia-flows-sdk": "23.2.1",
-    "preact": "10.6.6"
+    "preact": "10.11.2"
   }
 }

--- a/samples/flows/student-benefits/paginated/package.json
+++ b/samples/flows/student-benefits/paginated/package.json
@@ -4,12 +4,14 @@
   "version": "0.0.0",
   "license": "MIT",
   "devDependencies": {
-    "sanitize-html": "^2.7.2",
-    "ts-loader": "9.4.1",
-    "typescript": "4.8.4",
-    "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.11.1"
+    "@types/node": "18.0.0",
+    "sanitize-html": "^2.17.5",
+    "ts-loader": "9.5.4",
+    "tslib": "^2.8.1",
+    "typescript": "4.9.5",
+    "webpack": "^5.108.3",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.2.5"
   },
   "dependencies": {
     "@oracle/ia-flows-sdk": "23.2.1",

--- a/tools/web-projects-migrator/migrator/package.json
+++ b/tools/web-projects-migrator/migrator/package.json
@@ -5,14 +5,15 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@types/sax": "^1.2.4",
+    "@types/node": "^18.0.0",
+    "@types/sax": "^1.2.7",
     "decompress-unzip": "^4.0.1",
-    "esbuild": "^0.17.10",
-    "jsonc-parser": "^3.2.0",
-    "sax": "^1.2.4",
-    "ts-node": "^10.9.1",
-    "tsconfig-paths": "^4.1.1",
-    "typescript": "^4.9.4"
+    "esbuild": "^0.28.1",
+    "jsonc-parser": "^3.3.1",
+    "sax": "^1.6.0",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "build": "esbuild --bundle --platform=node --target=es2017 --outfile=build/migrate.js src/main.ts --main-fields=module,main"


### PR DESCRIPTION
This will resolve the issues with the existing esbuild and webpack-dev-server minimum versions in package.json files - I have updated all relevant package versions to match what is actually being pulled down.  

I also found a problem running the samples because the implicit @types/node package version was not compatible with typescript 4.x, so I've explictly tied that to @types/node 18.0.0 which is compatible.